### PR TITLE
Fix: Prevent buffer overflow in config loading

### DIFF
--- a/src/drivers/storage/nvMemory.cpp
+++ b/src/drivers/storage/nvMemory.cpp
@@ -91,8 +91,15 @@ bool nvMemory::loadConfig(TSettings* Settings)
                 if (!error)
                 {
                     Settings->PoolAddress = json[JSON_SPIFFS_KEY_POOLURL] | Settings->PoolAddress;
-                    strcpy(Settings->PoolPassword, json[JSON_SPIFFS_KEY_POOLPASS] | Settings->PoolPassword);
-                    strcpy(Settings->BtcWallet, json[JSON_SPIFFS_KEY_WALLETID] | Settings->BtcWallet);
+                    // Safely copy PoolPassword
+                    const char* poolPasswordSource = json[JSON_SPIFFS_KEY_POOLPASS] | Settings->PoolPassword;
+                    strncpy(Settings->PoolPassword, poolPasswordSource, sizeof(Settings->PoolPassword) - 1);
+                    Settings->PoolPassword[sizeof(Settings->PoolPassword) - 1] = '\0'; // Ensure null termination
+
+                    // Safely copy BtcWallet
+                    const char* btcWalletSource = json[JSON_SPIFFS_KEY_WALLETID] | Settings->BtcWallet;
+                    strncpy(Settings->BtcWallet, btcWalletSource, sizeof(Settings->BtcWallet) - 1);
+                    Settings->BtcWallet[sizeof(Settings->BtcWallet) - 1] = '\0'; // Ensure null termination
                     if (json.containsKey(JSON_SPIFFS_KEY_POOLPORT))
                         Settings->PoolPort = json[JSON_SPIFFS_KEY_POOLPORT].as<int>();
                     if (json.containsKey(JSON_SPIFFS_KEY_TIMEZONE))


### PR DESCRIPTION
Modified `nvMemory::loadConfig` to use `strncpy` instead of `strcpy` when loading `PoolPassword` and `BtcWallet` from the JSON configuration file. This prevents potential buffer overflows if the stored strings are too long for the fixed-size character arrays in the `TSettings` struct.

Ensured explicit null termination for these fields after `strncpy` to maintain string integrity.

This overflow could potentially corrupt the `TSettings` object, leading to issues such as WiFiManager not displaying all configuration parameters correctly on the web interface.